### PR TITLE
Adição de função geoip

### DIFF
--- a/hack-functions.sh
+++ b/hack-functions.sh
@@ -253,6 +253,14 @@ ip2bin()
 	echo
 }
 
+####################### Geo Coordenadas de um determinado IP ##########
+geoip()
+{
+        wget -q --timeout=30 "http://xml.utrace.de/?query=$1" -O - | sed '4d' | sed "s/<[^>]*>//g; s/\t//g; /^$/d" | tr '\n' ',' ; echo "\n"
+       
+}
+
+
 ####################### Engenharia Reversa ###########################
 
 # asmgrep - busca instruções assembly em binários executáveis


### PR DESCRIPTION
Adição de função para retornar localização aproximada de determinado endereço, retornando:

 LEVEL, Empresa/ISP,Latitude,Longitude,Quantidade de Requisições do dia,\n

Exemplo de utilização 

$ geoip 8.8.8.8
Level 3 Communications,Google Incorporated,Mountain View,US,37.419200897217,-122.05740356445,8,\n
$
