### PR TITLE
mudanças no unmd5

### DIFF
--- a/README
+++ b/README
@@ -47,7 +47,8 @@ hack-functions
  tee
  udcli e udis86 (sc2asm)
  nasm (asm2sc)
-
+ iw 
+ awk
 
 3. Instalação
  

--- a/hack-functions.sh
+++ b/hack-functions.sh
@@ -269,6 +269,39 @@ geoip()
        
 }
 
+####################### Imprime o IP externo da conexao ##############
+meuip()
+{
+	wget -q --timeout=30 "http://meuip.datahouse.com.br/" -O - | 
+	grep "Meu IP\?" | 
+	grep -Ewo "([0-9]){1,3}(\.([0-9]){1,3}){3}"
+
+}
+
+####################### Scan de Redes Sem Fio ########################
+wscan() 
+{
+	[ $# -ne 1 ] && echo "Informe uma interface EX: ./wscan wlan0 "
+
+        iface=$1
+        LISTA=""
+
+	echo -e "BSS\t\t\t  dBm\t ESSID\t\t\t C?  \t WPS?"
+
+	LISTA=($(iw dev ${iface} scan | 
+              grep -Ewo "BSS (([a-f|0-9][a-f|0-9]\:){5}([:a-f|0-9]+)|channel ([0-9]){1,2})|SSID: ([0-9a-zA-Z]){1,}|([0-9]+)\.00 dBm|WPA.*|WEP|WPS.*" |
+                tr '\n' ' ' | 
+                sed 's/SSID: //g; s/channel //g; s/dBm/\t\n/g;  s/BSS/|/g; s/Version://g; s/\*//g;' 2>/dev/null ) )
+
+	echo -e "${LISTA[@]}" | tr '|' '\n' | sed 's/: //g' |
+                awk '{  n=""
+                        for ( i=length($3) ; i<22 ; i++ ) n=n" "                
+                          print $1,"\t",$2,"\t",$3,n,$4,"   "$5 
+                        }'
+	echo " "
+
+}
+
 ####################### Engenharia Reversa ###########################
 
 # asmgrep - busca instruções assembly em binários executáveis


### PR DESCRIPTION
apenas adicionada outra fonte de pesquisa para o unmd5 uma vez que md5crack.com está fora, a fonte anterior foi mantida, tendo em vista que ele pode voltar a funcionar, sendo assim, mantendo duas fontes de consulta, caso não encontre em um pode ser que encontre em outro. 

apenas isso me preocupou, http://www.tobtu.com/files/eula.txt  mas, como nossos interesses são apenas de estudo e aprendizado, não sei se o comportamento de outras pessoas que baixem a ferramenta pode nos afetar diretamente. 
