### PR TITLE
bh_replacestring(): Replace strings that has the same size.

### DIFF
--- a/src/reversing/bh_replacestring.sh
+++ b/src/reversing/bh_replacestring.sh
@@ -1,0 +1,15 @@
+bh_replacestring() {
+	[[ -f "$1" && -n "$2" && -n "$3" && "${#2}" == "${#3}" ]] || return 1
+
+	local fil="$1"
+	local src="$2"
+	local dst="$3"
+
+    local srchex=$(echo $src | xxd -pu)
+    local dsthex=$(echo $dst | xxd -pu)
+
+	local tmpfile=".$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 16 | head -n 1)"
+
+    xxd -p < $fil | tr -d '\n' | sed "s/${srchex::-2}/${dsthex::-2}/g" | xxd -r -p > $tmpfile
+	cat $tmpfile > $fil && rm $tmpfile
+}


### PR DESCRIPTION
Adicionada a função `bh_replacestring`

Descrição: Função para substituir todas as ocorrências de uma string em um binário por uma outra de mesmo tamanho.

Modo de uso:

> `bh_replacestring binario stringasersubstituida stringsubstituta`

Exemplo de uso:

```
[79862] j3r3mias@tardis:testes > bh_skel_c | sed 's/return 0;/char *s = "menteb.in\/apoie";\n\tputs(s);\n\treturn 0;/g' > a.c

[79863] j3r3mias@tardis:testes > make a
cc     a.c   -o a

[79864] j3r3mias@tardis:testes > ./a 
menteb.in/apoie

[79865] j3r3mias@tardis:testes > bh_replacestring a "menteb.in/apoie" "mmmmentebinaria"

[79866] j3r3mias@tardis:testes > ./a 
mmmmentebinaria
```
