### PR TITLE
Adding support to BourneShell commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-SRC = $(shell find src/ -type f -name '*.sh')
+SRC = `find src/ -type f -name '*.sh'`
 OUTFILE = bashacks.sh
-BASHRCFILE = ~/.bash_profile
+BASHRCFILE = ~/.profile
 BASHACKS = $(shell pwd)/$(OUTFILE)
 
 all:
@@ -10,7 +10,7 @@ all:
 	done
 
 install:
-	[[ -e $(OUTFILE) ]] && \
+	[ -e $(OUTFILE) ] && \
 		echo -e "\n[[ -e $(BASHACKS) ]] && source $(BASHACKS)" >> $(BASHRCFILE) \
 	|| \
 		echo -e "$(OUTFILE) not found. Try: make\n"

--- a/Makefile
+++ b/Makefile
@@ -10,13 +10,11 @@ all:
 	done
 
 install:
+	[[ -e $(OUTFILE) ]] && \
+		echo -e "\n[[ -e $(BASHACKS) ]] && source $(BASHACKS)" >> $(BASHRCFILE) \
+	|| \
+		echo -e "$(OUTFILE) not found. Try: make\n"
 
-ifeq ("$(wildcard $(OUTFILE))","")
-	$(error $(OUTFILE) not found. Try: make)
-endif	
-
-	echo -e "\n[[ -e $(BASHACKS) ]] && source $(BASHACKS)" >> $(BASHRCFILE)
-	
 clean:
 	rm -f bashacks.sh
 


### PR DESCRIPTION
Now the Makefile can install **bashacks** in systems that use sh(BourneShell), for me that sounds weird because the project name is 'BASHacks'. Anyway, some alterations in auto-load script local are changed: **~/.bash_profile** to **~/.profile**.