### PR TITLE
some changes in crypto scripts

### DIFF
--- a/src/crypto/bh_hashcrack.sh
+++ b/src/crypto/bh_hashcrack.sh
@@ -1,9 +1,9 @@
 bh_hashcrack() {
 	# argc must be equals to 1
-	[ $# -ne 1 ] && return 1
+	[[ $# -ne 1 ]] && return 1
 
 	# if '${HOME}/.config/bashacks/' not exist
-	[ ! -d "$BASHACKS_CACHEDIR" ] && {
+	[[ ! -d "$BASHACKS_CACHEDIR" ]] && {
 		mkdir -p "$BASHACKS_CACHEDIR"
 		> "${BASHACKS_CACHEDIR}/hash"
    }
@@ -14,7 +14,7 @@ bh_hashcrack() {
    # cache search
    CACHE=$(grep "${hash}:" "${BASHACKS_CACHEDIR}/hash" )
 
-   if [ "$CACHE" ]; then
+   if [[ "$CACHE" ]]; then
 		# getting the plaintext that is hashed
 		res=$(cut -d ':' -f2 <<< "$CACHE")
 
@@ -25,7 +25,7 @@ bh_hashcrack() {
 			| sed -n '/.*generate-hash\/?text=\(.*\)\".*/{s//\1/p;q;}')
 
       # saving data on cache
-      [ "$res" ] && \
+      [[ "$res" ]] && \
 			echo "${hash}:$res" >> "${BASHACKS_CACHEDIR}/hash"
 	fi
 

--- a/src/crypto/bh_hashcrack.sh
+++ b/src/crypto/bh_hashcrack.sh
@@ -15,6 +15,7 @@ bh_hashcrack() {
    CACHE=$(grep "${hash}:" "${BASHACKS_CACHEDIR}/hash" )
 
    if [ "$CACHE" ]; then
+		# getting the plaintext that is hashed
 		res=$(cut -d ':' -f2 <<< "$CACHE")
 
 	# if the hash has not been looked up previously
@@ -23,7 +24,7 @@ bh_hashcrack() {
       res=$(bh_cmd_wget -qO - "$site" \
 			| sed -n '/.*generate-hash\/?text=\(.*\)\".*/{s//\1/p;q;}')
 
-      # cache
+      # saving data on cache
       [ "$res" ] && \
 			echo "${hash}:$res" >> "${BASHACKS_CACHEDIR}/hash"
 	fi

--- a/src/crypto/bh_rot.sh
+++ b/src/crypto/bh_rot.sh
@@ -1,7 +1,7 @@
 bh_rot() {
 	local n
 
-	[ $# -eq 2 ] || return 1
+	[[ $# -eq 2 ]] || return 1
 
 	# n receives the correspondent alphabet letter
 	n=$(echo -e \\x$(bh_dec2hex $(( 97 + $1 )) ) )

--- a/src/crypto/bh_rot.sh
+++ b/src/crypto/bh_rot.sh
@@ -1,12 +1,13 @@
-bh_rot()
-{
-	local n=
+bh_rot() {
+	local n
 
-	[[ $# -eq 2 ]] || return 1 
+	[ $# -eq 2 ] || return 1
 
 	# n receives the correspondent alphabet letter
-	n=$(echo -e \\x$(bh_dec2hex $(echo -e $((97+$1)))))
-	N=$(echo $n | tr a-z A-Z)
+	n=$(echo -e \\x$(bh_dec2hex $(( 97 + $1 )) ) )
+
+	# bash idiom to turn our text in uppercase letters
+	N="${n^^}"
 
 	# rot with tr command
 	echo $2 | tr a-z $n-za-z | tr A-Z $N-ZA-Z

--- a/src/crypto/bh_rotall.sh
+++ b/src/crypto/bh_rotall.sh
@@ -1,5 +1,4 @@
-bh_rotall()
-{
+bh_rotall() {
 	local i
 
 	test -n "$1" || { bh_rot ; return 1; }


### PR DESCRIPTION
### bh_hashcrack

- again: **[[ ]]** is a regex test, stop using this on simple test,  this can make the script slower
- don't use excess curly braces to group commands in a condition, it's less readable, if;then;else is preferable

### bh_rot

- changing regex test to simple test
- in the string operations, bash variable expansion says: 'i'm speed!'

### bh_rotall

- simple change to follow a coding model

### bh_strxor

- [BUG] an issue related to this is opening 
- att: issue opened: https://github.com/merces/bashacks/issues/44