### PR TITLE
using only loop, param expansion and printf to convert string to integer

### DIFF
--- a/src/strings/bh_str2dec.sh
+++ b/src/strings/bh_str2dec.sh
@@ -1,7 +1,9 @@
 bh_str2dec() {
 	(( $# < 1 )) && return 1
 
-	echo -n "$1" | hexdump -ve '/1 "%d "' | sed 's/\(.*\) /\1/'
+	for i in ${1//?/& }; do
+		printf "%d " "'$i'"
+	done
 	echo
 }
 


### PR DESCRIPTION
Hello, it's been a while :)

This PR proposes using  only `printf` to convert string to integer.
For example, if we try to convert chars that the ASCII Table doesn't include, we'll get a negative number:

```bash
$ bh_str2dec "olá mundo"
111 108 -61 -95 32 109 117 110 100 111
```

But, with `printf`  we get the positive value beyond the scope of ASCII:

```bash
$ bh_str2dec "olá mundo"
111 108 225 109 117 110 100 111
```