### PR TITLE
avoiding the usage of patsub_replacement

### DIFF
--- a/src/strings/bh_str2dec.sh
+++ b/src/strings/bh_str2dec.sh
@@ -1,9 +1,19 @@
 bh_str2dec() {
 	(( $# < 1 )) && return 1
 
-	for i in ${1//?/& }; do
-		printf "%d " "'$i'"
+	# count the number of digits of the param ($1)
+	# and print each one with printf in the decimal format
+	#
+	local param_length=${#1}
+	for (( i=0; i<$param_length; i++ )); do
+
+		# avoid the last space in the last char, if this last space exists
+		# other modules can fail
+		(( (i + 1) < param_length )) && { printf "%d " "'${1:$i:1}'"; continue; }
+
+		printf "%d" "'${1:$i:1}'"
 	done
+
 	echo
 }
 
@@ -11,5 +21,5 @@ bh_asc2dec() {
     echo "WARNING: bh_asc2dec() is depcreated and will be removed in the next release. Use bh_str2dec() instead."
 	(( $# < 1 )) && return 1
 
-	bh_str2dec $1
+	bh_str2dec "$1"
 }


### PR DESCRIPTION
Hello.
I noticed that the `${foo//?/& }` feature used in #53 only comes in the [version 5.2](https://mywiki.wooledge.org/BashFAQ/061) of Bash, with the name `patsub_replacement`.
This projects requires Bash version >= 4, so this PR comes to avoid using this functionality, using only the basics of parameter expansion.